### PR TITLE
fix: Docker localhost will not be exposed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /
 
 COPY . ./
 
-CMD ["run", "-A", "dist/app.js", "--address", "localhost:8000", "--serve-path", "dist/static"] 
+CMD ["run", "-A", "dist/app.js", "--address", "0.0.0.0:8000", "--serve-path", "dist/static"] 


### PR DESCRIPTION
The server might start, but somehow docker will not recognize localhost
and thus the port will not be exposed. 0.0.0.0 has to be used instead of
localhost.